### PR TITLE
Extended statement support and unified bank account operations

### DIFF
--- a/Parser/ABO/TatraBankaSKParser.php
+++ b/Parser/ABO/TatraBankaSKParser.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace JakubZapletal\Component\BankStatement\Parser\ABO;
+
+use JakubZapletal\Component\BankStatement\Parser\ABOParser;
+
+class TatraBankaSKParser extends ABOParser
+{
+    protected function parseAccountNumber($line)
+    {
+        $number = str_pad(substr($line, 3, 10), 10, '0', STR_PAD_LEFT);
+        $prefix = ltrim(substr($line, 13, 6), '0');
+        return $prefix . $this->decodeAccountNumber($number);
+    }
+
+    protected function parseCounterAccountNumber($line)
+    {
+        $number = str_pad(substr($line, 19, 10), 10, '0', STR_PAD_LEFT);
+        $prefix = ltrim(substr($line, 34, 6), '0');
+        $codeOfBank = substr($line, 73, 4);
+        return $prefix . $this->decodeAccountNumber($number) . '/' . $codeOfBank;
+    }
+
+    private function decodeAccountNumber($number)
+    {
+        return $number[4] . $number[5] . $number[6] . $number[7] . $number[8] . $number[3] . $number[9] . $number[1] . $number[2] . $number[0];
+    }
+}

--- a/Parser/ABO/TatraBankaSKParser.php
+++ b/Parser/ABO/TatraBankaSKParser.php
@@ -3,24 +3,37 @@
 namespace JakubZapletal\Component\BankStatement\Parser\ABO;
 
 use JakubZapletal\Component\BankStatement\Parser\ABOParser;
+use JakubZapletal\Component\BankStatement\Statement\BankAccount;
 
 class TatraBankaSKParser extends ABOParser
 {
+    /**
+     * @param $line
+     * @return BankAccount
+     */
     protected function parseAccountNumber($line)
     {
-        $number = str_pad(substr($line, 3, 10), 10, '0', STR_PAD_LEFT);
         $prefix = ltrim(substr($line, 13, 6), '0');
-        return $prefix . $this->decodeAccountNumber($number);
+        $number = ltrim($this->decodeAccountNumber(substr($line, 3, 10)), '0');
+        return new BankAccount($prefix, $number, '1100');
     }
 
+    /**
+     * @param $line
+     * @return BankAccount
+     */
     protected function parseCounterAccountNumber($line)
     {
-        $number = str_pad(substr($line, 19, 10), 10, '0', STR_PAD_LEFT);
-        $prefix = ltrim(substr($line, 34, 6), '0');
-        $codeOfBank = substr($line, 73, 4);
-        return $prefix . $this->decodeAccountNumber($number) . '/' . $codeOfBank;
+        $prefix = ltrim(substr($line, 29, 6), '0');
+        $number = ltrim($this->decodeAccountNumber(substr($line, 19, 10)), '0');
+        $bankCode = ltrim(substr($line, 73, 4), '0');
+        return new BankAccount($prefix, $number, $bankCode);
     }
 
+    /**
+     * @param $number
+     * @return string
+     */
     private function decodeAccountNumber($number)
     {
         return $number[4] . $number[5] . $number[6] . $number[7] . $number[8] . $number[3] . $number[9] . $number[1] . $number[2] . $number[0];

--- a/Parser/ABOParser.php
+++ b/Parser/ABOParser.php
@@ -15,12 +15,12 @@ use JakubZapletal\Component\BankStatement\Statement\Transaction\Transaction;
  */
 class ABOParser extends Parser
 {
-    const LINE_TYPE_STATEMENT   = 'statement';
+    const LINE_TYPE_STATEMENT = 'statement';
     const LINE_TYPE_TRANSACTION = 'transaction';
 
-    const POSTING_CODE_DEBIT           = 1;
-    const POSTING_CODE_CREDIT          = 2;
-    const POSTING_CODE_DEBIT_REVERSAL  = 4;
+    const POSTING_CODE_DEBIT = 1;
+    const POSTING_CODE_CREDIT = 2;
+    const POSTING_CODE_DEBIT_REVERSAL = 4;
     const POSTING_CODE_CREDIT_REVERSAL = 5;
 
     /**
@@ -124,54 +124,28 @@ class ABOParser extends Parser
     protected function parseStatementLine($line)
     {
         # Account number
-        $accountNumber = ltrim(substr($line, 3, 16), '0');
-        $this->statement->setAccountNumber($accountNumber);
+        $this->statement->setAccountNumber($this->parseAccountNumber($line));
 
         # Date last balance
-        $date = substr($line, 39, 6);
-        $dateLastBalance = \DateTime::createFromFormat('dmyHis', $date . '120000');
-        $this->statement->setDateLastBalance($dateLastBalance);
+        $this->statement->setDateLastBalance($this->parseDateLastBalance($line));
 
         # Last balance
-        $lastBalance = ltrim(substr($line, 45, 14), '0') / 100;
-        $lastBalanceSign = substr($line, 59, 1);
-        if ($lastBalanceSign === '-') {
-            $lastBalance *= -1;
-        }
-        $this->statement->setLastBalance($lastBalance);
+        $this->statement->setLastBalance($this->parseLastBalance($line));
 
         # Balance
-        $balance = ltrim(substr($line, 60, 14), '0') / 100;
-        $balanceSign = substr($line, 74, 1);
-        if ($balanceSign === '-') {
-            $balance *= -1;
-        }
-        $this->statement->setBalance($balance);
+        $this->statement->setBalance($this->parseBalance($line));
 
         # Debit turnover
-        $debitTurnover = ltrim(substr($line, 75, 14), '0') / 100;
-        $debitTurnoverSign = substr($line, 89, 1);
-        if ($debitTurnoverSign === '-') {
-            $debitTurnover *= -1;
-        }
-        $this->statement->setDebitTurnover($debitTurnover);
+        $this->statement->setDebitTurnover($this->parseDebitTurnover($line));
 
         # Credit turnover
-        $creditTurnover = ltrim(substr($line, 90, 14), '0') / 100;
-        $creditTurnoverSign = substr($line, 104, 1);
-        if ($creditTurnoverSign === '-') {
-            $creditTurnover *= -1;
-        }
-        $this->statement->setCreditTurnover($creditTurnover);
+        $this->statement->setCreditTurnover($this->parseCreditTurnover($line));
 
         # Serial number
-        $serialNumber = substr($line, 105, 3) * 1;
-        $this->statement->setSerialNumber($serialNumber);
+        $this->statement->setSerialNumber($this->parseSerialNumber($line));
 
         # Date created
-        $date = substr($line, 108, 6);
-        $dateCreated = \DateTime::createFromFormat('dmyHis', $date . '120000');
-        $this->statement->setDateCreated($dateCreated);
+        $this->statement->setDateCreated($this->parseDateCreated($line));
     }
 
     /**
@@ -204,53 +178,220 @@ class ABOParser extends Parser
         $transaction = $this->getTransactionClass();
 
         # Receipt ID
-        $receiptId = ltrim(substr($line, 35, 13), '0');
-        $transaction->setReceiptId($receiptId);
+        $transaction->setReceiptId($this->parseReceiptId($line));
 
         # Debit / Credit
-        $amount = ltrim(substr($line, 48, 12), '0') / 100;
-        $postingCode = substr($line, 60, 1);
-        switch ($postingCode) {
+        switch ($this->parsePostingCode($line)) {
             case self::POSTING_CODE_DEBIT:
-                $transaction->setDebit($amount);
+                $transaction->setDebit($this->parseAmount($line));
                 break;
             case self::POSTING_CODE_CREDIT:
-                $transaction->setCredit($amount);
+                $transaction->setCredit($this->parseAmount($line));
                 break;
             case self::POSTING_CODE_DEBIT_REVERSAL:
-                $transaction->setDebit($amount * (-1));
+                $transaction->setDebit($this->parseAmount($line) * (-1));
                 break;
             case self::POSTING_CODE_CREDIT_REVERSAL:
-                $transaction->setCredit($amount * (-1));
+                $transaction->setCredit($this->parseAmount($line) * (-1));
                 break;
         }
 
         # Variable symbol
-        $variableSymbol = ltrim(substr($line, 61, 10), '0');
-        $transaction->setVariableSymbol($variableSymbol);
+        $transaction->setVariableSymbol($this->parseVariableSymbol($line));
 
         # Constant symbol
-        $constantSymbol = ltrim(substr($line, 77, 4), '0');
-        $transaction->setConstantSymbol($constantSymbol);
+        $transaction->setConstantSymbol($this->parseConstantSymbol($line));
 
         # Counter account number
-        $counterAccountNumber = ltrim(substr($line, 19, 16), '0');
-        $codeOfBank = substr($line, 73, 4);
-        $transaction->setCounterAccountNumber($counterAccountNumber . '/' . $codeOfBank);
+        $transaction->setCounterAccountNumber($this->parseCounterAccountNumber($line));
 
         # Specific symbol
-        $specificSymbol = ltrim(substr($line, 81, 10), '0');
-        $transaction->setSpecificSymbol($specificSymbol);
+        $transaction->setSpecificSymbol($this->parseSpecificSymbol($line));
 
         # Note
-        $note = rtrim(substr($line, 97, 20));
-        $transaction->setNote($note);
+        $transaction->setNote($this->parseNote($line));
 
         # Date created
-        $date = substr($line, 122, 6);
-        $dateCreated = \DateTime::createFromFormat('dmyHis', $date . '120000');
-        $transaction->setDateCreated($dateCreated);
+        $transaction->setDateCreated($this->parseTransactionDateCreated($line));
 
         return $transaction;
+    }
+
+    /**
+     * @param $line
+     * @return string
+     */
+    protected function parseAccountNumber($line)
+    {
+        return ltrim(substr($line, 3, 16), '0');
+    }
+
+    /**
+     * @param $line
+     * @return \DateTime
+     */
+    protected function parseDateLastBalance($line)
+    {
+        $date = substr($line, 39, 6);
+        return \DateTime::createFromFormat('dmyHis', $date . '120000');
+    }
+
+    /**
+     * @param $line
+     * @return float|int
+     */
+    protected function parseLastBalance($line)
+    {
+        $lastBalance = ltrim(substr($line, 45, 14), '0') / 100;
+        $lastBalanceSign = substr($line, 59, 1);
+        if ($lastBalanceSign === '-') {
+            $lastBalance *= -1;
+        }
+        return $lastBalance;
+    }
+
+    /**
+     * @param $line
+     * @return float|int
+     */
+    protected function parseBalance($line)
+    {
+        $balance = ltrim(substr($line, 60, 14), '0') / 100;
+        $balanceSign = substr($line, 74, 1);
+        if ($balanceSign === '-') {
+            $balance *= -1;
+        }
+        return $balance;
+    }
+
+    /**
+     * @param $line
+     * @return float|int
+     */
+    protected function parseDebitTurnover($line)
+    {
+        $debitTurnover = ltrim(substr($line, 75, 14), '0') / 100;
+        $debitTurnoverSign = substr($line, 89, 1);
+        if ($debitTurnoverSign === '-') {
+            $debitTurnover *= -1;
+        }
+        return $debitTurnover;
+    }
+
+    /**
+     * @param $line
+     * @return float|int
+     */
+    protected function parseCreditTurnover($line)
+    {
+        $creditTurnover = ltrim(substr($line, 90, 14), '0') / 100;
+        $creditTurnoverSign = substr($line, 104, 1);
+        if ($creditTurnoverSign === '-') {
+            $creditTurnover *= -1;
+        }
+        return $creditTurnover;
+    }
+
+    /**
+     * @param $line
+     * @return string
+     */
+    protected function parseSerialNumber($line)
+    {
+        return substr($line, 105, 3) * 1;
+    }
+
+    /**
+     * @param $line
+     * @return \DateTime
+     */
+    protected function parseDateCreated($line)
+    {
+        $date = substr($line, 108, 6);
+        return \DateTime::createFromFormat('dmyHis', $date . '120000');
+    }
+
+    /**
+     * @param $line
+     * @return string
+     */
+    protected function parseReceiptId($line)
+    {
+        return ltrim(substr($line, 35, 13), '0');
+    }
+
+    /**
+     * @param $line
+     * @return float
+     */
+    protected function parseAmount($line)
+    {
+        return ltrim(substr($line, 48, 12), '0') / 100;
+    }
+
+    /**
+     * @param $line
+     * @return int
+     */
+    protected function parsePostingCode($line)
+    {
+        return intval(substr($line, 60, 1));
+    }
+
+    /**
+     * @param $line
+     * @return string
+     */
+    protected function parseVariableSymbol($line)
+    {
+        return ltrim(substr($line, 61, 10), '0');
+    }
+
+    /**
+     * @param $line
+     * @return string
+     */
+    protected function parseConstantSymbol($line)
+    {
+        return ltrim(substr($line, 77, 4), '0');
+    }
+
+    /**
+     * @param $line
+     * @return string
+     */
+    protected function parseCounterAccountNumber($line)
+    {
+        $counterAccountNumber = ltrim(substr($line, 19, 16), '0');
+        $codeOfBank = substr($line, 73, 4);
+        return $counterAccountNumber . '/' . $codeOfBank;
+    }
+
+    /**
+     * @param $line
+     * @return string
+     */
+    protected function parseSpecificSymbol($line)
+    {
+        return ltrim(substr($line, 81, 10), '0');
+    }
+
+    /**
+     * @param $line
+     * @return string
+     */
+    protected function parseNote($line)
+    {
+        return rtrim(substr($line, 97, 20));
+    }
+
+    /**
+     * @param $line
+     * @return \DateTime
+     */
+    protected function parseTransactionDateCreated($line)
+    {
+        $date = substr($line, 122, 6);
+        return \DateTime::createFromFormat('dmyHis', $date . '120000');
     }
 }

--- a/Parser/ABOParser.php
+++ b/Parser/ABOParser.php
@@ -2,6 +2,7 @@
 
 namespace JakubZapletal\Component\BankStatement\Parser;
 
+use JakubZapletal\Component\BankStatement\Statement\BankAccount;
 use JakubZapletal\Component\BankStatement\Statement\Statement;
 use JakubZapletal\Component\BankStatement\Statement\Transaction\Transaction;
 
@@ -124,7 +125,7 @@ class ABOParser extends Parser
     protected function parseStatementLine($line)
     {
         # Account number
-        $this->statement->setAccountNumber($this->parseAccountNumber($line));
+        $this->statement->setBankAccount($this->parseBankAccount($line));
 
         # Date last balance
         $this->statement->setDateLastBalance($this->parseDateLastBalance($line));
@@ -203,7 +204,7 @@ class ABOParser extends Parser
         $transaction->setConstantSymbol($this->parseConstantSymbol($line));
 
         # Counter account number
-        $transaction->setCounterAccountNumber($this->parseCounterAccountNumber($line));
+        $transaction->setCounterBankAccount($this->parseCounterBankAccount($line));
 
         # Specific symbol
         $transaction->setSpecificSymbol($this->parseSpecificSymbol($line));
@@ -219,11 +220,13 @@ class ABOParser extends Parser
 
     /**
      * @param $line
-     * @return string
+     * @return BankAccount
      */
-    protected function parseAccountNumber($line)
+    protected function parseBankAccount($line)
     {
-        return ltrim(substr($line, 3, 16), '0');
+        $prefix = ltrim(substr($line, 3, 6), '0');
+        $number = ltrim(substr($line, 9, 10), '0');
+        return new BankAccount($prefix, $number);
     }
 
     /**
@@ -358,13 +361,14 @@ class ABOParser extends Parser
 
     /**
      * @param $line
-     * @return string
+     * @return BankAccount
      */
-    protected function parseCounterAccountNumber($line)
+    protected function parseCounterBankAccount($line)
     {
-        $counterAccountNumber = ltrim(substr($line, 19, 16), '0');
-        $codeOfBank = substr($line, 73, 4);
-        return $counterAccountNumber . '/' . $codeOfBank;
+        $prefix = ltrim(substr($line, 19, 6), '0');
+        $number = ltrim(substr($line, 25, 10), '0');
+        $bankCode = ltrim(substr($line, 73, 4), '0');
+        return new BankAccount($prefix, $number, $bankCode);
     }
 
     /**

--- a/Parser/XML/CSOBCZParser.php
+++ b/Parser/XML/CSOBCZParser.php
@@ -3,14 +3,15 @@
 namespace JakubZapletal\Component\BankStatement\Parser\XML;
 
 use JakubZapletal\Component\BankStatement\Parser\XMLParser;
+use JakubZapletal\Component\BankStatement\Statement\BankAccount;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\CssSelector\CssSelector;
 
 class CSOBCZParser extends XMLParser
 {
-    const POSTING_CODE_DEBIT           = 'D';
-    const POSTING_CODE_CREDIT          = 'C';
-    const POSTING_CODE_DEBIT_REVERSAL  = 'DR';
+    const POSTING_CODE_DEBIT = 'D';
+    const POSTING_CODE_CREDIT = 'C';
+    const POSTING_CODE_DEBIT_REVERSAL = 'DR';
     const POSTING_CODE_CREDIT_REVERSAL = 'CR';
 
     /**
@@ -92,8 +93,9 @@ class CSOBCZParser extends XMLParser
     protected function parseStatementNode(Crawler $crawler)
     {
         # Account number
-        $accountNumber = $crawler->filter('S25_CISLO_UCTU')->text();
-        $this->statement->setAccountNumber($accountNumber);
+        $bankAccount = new BankAccount();
+        $bankAccount->setFormatted($crawler->filter('S25_CISLO_UCTU')->text());
+        $this->statement->setBankAccount($bankAccount);
 
         # Date last balance
         $date = $crawler->filter('S60_DATUM')->text();
@@ -230,7 +232,9 @@ class CSOBCZParser extends XMLParser
         # Counter account number
         $counterAccountNumber = $crawler->filter('PART_ACCNO')->text();
         $codeOfBank = $crawler->filter('PART_BANK_ID')->text();
-        $transaction->setCounterAccountNumber($counterAccountNumber . '/' . $codeOfBank);
+        $bankAccount = new BankAccount();
+        $bankAccount->setFormatted($counterAccountNumber . '/' . $codeOfBank);
+        $transaction->setCounterBankAccount($bankAccount);
 
         # Specific symbol
         $specificSymbol = $crawler->filter('S86_SPECSYMOUR')->text();

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ information about transactions.
 ### Supported formats/bank list
 
 * ABO (`*.gpc`) [[doc](doc/abo.md)]
+ * TatraBanka (SK): `JakubZapletal\Component\BankStatement\Parser\ABO\TatraBankaSKParser`
+ * UniCredit Bank (SK): `JakubZapletal\Component\BankStatement\Parser\ABO\TatraBankaSKParser`
+ * Česká spořitelna (CZ): `JakubZapletal\Component\BankStatement\Parser\ABO\CeskaSporitelnaCZParser`
  * Česká spořitelna (CZ): `JakubZapletal\Component\BankStatement\Parser\ABO\CeskaSporitelnaCZParser`
  * ČSOB (CZ): `JakubZapletal\Component\BankStatement\Parser\ABOParser`
  * Fio banka (CZ): `JakubZapletal\Component\BankStatement\Parser\ABOParser`

--- a/Statement/BankAccount.php
+++ b/Statement/BankAccount.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace JakubZapletal\Component\BankStatement\Statement;
+
+/**
+ * Class BankAccount
+ * @package JakubZapletal\Component\BankStatement\Statement
+ */
+class BankAccount
+{
+
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * @var string
+     */
+    private $number;
+
+    /**
+     * @var string
+     */
+    private $bankCode;
+
+    /**
+     * @param string|null $prefix
+     * @param string|null $number
+     * @param string|null $bankCode
+     */
+    function __construct($prefix = null, $number = null, $bankCode = null)
+    {
+        $this->prefix = $prefix;
+        $this->number = $number;
+        $this->bankCode = $bankCode;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * @param $prefix
+     *
+     * @return $this
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNumber()
+    {
+        return $this->number;
+    }
+
+    /**
+     * @param $number
+     *
+     * @return $this
+     */
+    public function setNumber($number)
+    {
+        $this->number = $number;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getBankCode()
+    {
+        return $this->bankCode;
+    }
+
+    /**
+     * @param $bankCode
+     *
+     * @return $this
+     */
+    public function setBankCode($bankCode)
+    {
+        $this->bankCode = $bankCode;
+        return
+            $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFormatted()
+    {
+        $formatted = sprintf('%s-%s/%s', $this->prefix, $this->number, $this->bankCode);
+        $formatted = ltrim($formatted, '-');
+        $formatted = rtrim($formatted, '/');
+        return trim($formatted);
+    }
+
+    /**
+     * @param $accountNumber
+     * @return $this
+     */
+    public function setFormatted($accountNumber)
+    {
+        $splitBankCode = explode('/', $accountNumber);
+        if (count($splitBankCode) === 2) {
+            $this->bankCode = $splitBankCode[1];
+        }
+        $splitNumber = explode('-', $splitBankCode[0]);
+        if (count($splitNumber) === 2) {
+            $this->prefix = $splitNumber[0];
+            $this->number = $splitNumber[1];
+        } else {
+            if (strlen($splitNumber[0]) <= 10) {
+                $this->number = $splitNumber[0];
+            } else {
+                $this->prefix = substr($splitNumber[0], 0, strlen($splitNumber[0]) - 10);
+                $this->number = substr($splitNumber[0], -10, 10);
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return (empty($this->prefix) && empty($this->number) && empty($this->bankCode));
+    }
+
+}

--- a/Statement/Statement.php
+++ b/Statement/Statement.php
@@ -6,10 +6,11 @@ use JakubZapletal\Component\BankStatement\Statement\Transaction\TransactionInter
 
 class Statement implements StatementInterface, \Countable, \Iterator
 {
+
     /**
-     * @var string
+     * @var BankAccount
      */
-    protected $accountNumber;
+    protected $bankAccount;
 
     /**
      * @var float
@@ -66,7 +67,7 @@ class Statement implements StatementInterface, \Countable, \Iterator
      */
     public function setBalance($balance)
     {
-        $this->balance = (float) $balance;
+        $this->balance = (float)$balance;
 
         return $this;
     }
@@ -86,7 +87,7 @@ class Statement implements StatementInterface, \Countable, \Iterator
      */
     public function setCreditTurnover($creditTurnover)
     {
-        $this->creditTurnover = (float) $creditTurnover;
+        $this->creditTurnover = (float)$creditTurnover;
 
         return $this;
     }
@@ -146,64 +147,63 @@ class Statement implements StatementInterface, \Countable, \Iterator
      */
     public function setDebitTurnover($debitTurnover)
     {
-        $this->debitTurnover = (float) $debitTurnover;
+        $this->debitTurnover = (float)$debitTurnover;
 
         return $this;
     }
 
     /**
+     * @return BankAccount
+     */
+    public function getBankAccount()
+    {
+        return $this->bankAccount;
+    }
+
+    /**
+     * @param BankAccount $bankAccount
+     *
+     * @return $this
+     */
+    public function setBankAccount(BankAccount $bankAccount)
+    {
+        $this->bankAccount = $bankAccount;
+
+        return $this;
+    }
+
+    /**
+     * Only for backward compatibility
+     * @deprecated
+     *
      * @return string
      */
     public function getAccountNumber()
     {
-        return $this->accountNumber;
+        if ($this->bankAccount === null) {
+            return null;
+        }
+        return $this->bankAccount->getFormatted();
     }
 
     /**
-     * @param $accountNumber
-     *
-     * @return $this
-     */
-    public function setAccountNumber($accountNumber)
-    {
-        $this->accountNumber = $accountNumber;
-
-        return $this;
-    }
-
-    /**
-     * Split account number to parts
+     * Only for backward compatibility
+     * @deprecated
      *
      * @return array
      */
     public function getParsedAccountNumber()
     {
         $parsedAccountNumber = array(
-            'prefix'   => null,
-            'number'   => null,
+            'prefix' => null,
+            'number' => null,
             'bankCode' => null
         );
-
-        $accountNumber = $this->getAccountNumber();
-
-        $splitBankCode = explode('/', $accountNumber);
-        if (count($splitBankCode) === 2) {
-            $parsedAccountNumber['bankCode'] = $splitBankCode[1];
+        if ($this->bankAccount !== null) {
+            $parsedAccountNumber['prefix'] = $this->bankAccount->getPrefix();
+            $parsedAccountNumber['number'] = $this->bankAccount->getNumber();
+            $parsedAccountNumber['bankCode'] = $this->bankAccount->getBankCode();
         }
-
-        $splitNumber = explode('-', $splitBankCode[0]);
-        if (count($splitNumber) === 2) {
-            $parsedAccountNumber['prefix'] = $splitNumber[0];
-            $parsedAccountNumber['number'] = $splitNumber[1];
-        } else {
-            if (strlen($splitNumber[0]) <= 10) {
-                $parsedAccountNumber['number'] = $splitNumber[0];
-            } else {
-                $parsedAccountNumber['prefix'] = substr($splitNumber[0], 0, strlen($splitNumber[0]) - 10);
-                $parsedAccountNumber['number'] = substr($splitNumber[0], -10, 10);
-            }
-        }
-
         return $parsedAccountNumber;
     }
 
@@ -242,7 +242,7 @@ class Statement implements StatementInterface, \Countable, \Iterator
      */
     public function setLastBalance($lastBalance)
     {
-        $this->lastBalance = (float) $lastBalance;
+        $this->lastBalance = (float)$lastBalance;
 
         return $this;
     }

--- a/Statement/StatementInterface.php
+++ b/Statement/StatementInterface.php
@@ -71,16 +71,23 @@ interface StatementInterface
     public function setDebitTurnover($debitTurnover);
 
     /**
-     * @return string
+     * @return BankAccount
      */
-    public function getAccountNumber();
+    public function getBankAccount();
 
     /**
-     * @param $accountNumber
+     * @param BankAccount $bankAccount
      *
      * @return $this
      */
-    public function setAccountNumber($accountNumber);
+    public function setBankAccount(BankAccount $bankAccount);
+
+    /**
+     * @deprecated
+     *
+     * @return string
+     */
+    public function getAccountNumber();
 
     /**
      * @return TransactionInterface[]

--- a/Statement/Transaction/Transaction.php
+++ b/Statement/Transaction/Transaction.php
@@ -2,12 +2,14 @@
 
 namespace JakubZapletal\Component\BankStatement\Statement\Transaction;
 
+use JakubZapletal\Component\BankStatement\Statement\BankAccount;
+
 class Transaction implements TransactionInterface
 {
     /**
-     * @var string
+     * @var BankAccount
      */
-    protected $counterAccountNumber;
+    protected $counterBankAccount;
 
     /**
      * @var string
@@ -50,21 +52,35 @@ class Transaction implements TransactionInterface
     protected $dateCreated;
 
     /**
+     * Only for backward compatibility
+     * @deprecated
+     *
      * @return string
      */
     public function getCounterAccountNumber()
     {
-        return $this->counterAccountNumber;
+        if ($this->counterBankAccount === null) {
+            return null;
+        }
+        return $this->counterBankAccount->getFormatted();
     }
 
     /**
-     * @param $counterAccountNumber
+     * @return BankAccount
+     */
+    public function getCounterBankAccount()
+    {
+        return $this->counterBankAccount;
+    }
+
+    /**
+     * @param BankAccount $counterBankAccount
      *
      * @return $this
      */
-    public function setCounterAccountNumber($counterAccountNumber)
+    public function setCounterBankAccount(BankAccount $counterBankAccount)
     {
-        $this->counterAccountNumber = $counterAccountNumber;
+        $this->counterBankAccount = $counterBankAccount;
 
         return $this;
     }
@@ -84,7 +100,7 @@ class Transaction implements TransactionInterface
      */
     public function setConstantSymbol($constantSymbol)
     {
-        $this->constantSymbol = (int) $constantSymbol;
+        $this->constantSymbol = (int)$constantSymbol;
 
         return $this;
     }
@@ -104,7 +120,7 @@ class Transaction implements TransactionInterface
      */
     public function setCredit($credit)
     {
-        $this->credit = (float) $credit;
+        $this->credit = (float)$credit;
 
         return $this;
     }
@@ -144,7 +160,7 @@ class Transaction implements TransactionInterface
      */
     public function setDebit($debit)
     {
-        $this->debit = (float) $debit;
+        $this->debit = (float)$debit;
 
         return $this;
     }
@@ -204,7 +220,7 @@ class Transaction implements TransactionInterface
      */
     public function setSpecificSymbol($specificSymbol)
     {
-        $this->specificSymbol = (int) $specificSymbol;
+        $this->specificSymbol = (int)$specificSymbol;
 
         return $this;
     }
@@ -224,7 +240,7 @@ class Transaction implements TransactionInterface
      */
     public function setVariableSymbol($variableSymbol)
     {
-        $this->variableSymbol = (int) $variableSymbol;
+        $this->variableSymbol = (int)$variableSymbol;
 
         return $this;
     }

--- a/Statement/Transaction/TransactionInterface.php
+++ b/Statement/Transaction/TransactionInterface.php
@@ -2,19 +2,28 @@
 
 namespace JakubZapletal\Component\BankStatement\Statement\Transaction;
 
+use JakubZapletal\Component\BankStatement\Statement\BankAccount;
+
 interface TransactionInterface
 {
     /**
+     * @deprecated
+     *
      * @return string
      */
     public function getCounterAccountNumber();
 
     /**
-     * @param $counterAccountNumber
+     * @return BankAccount
+     */
+    public function getCounterBankAccount();
+
+    /**
+     * @param BankAccount $counterBankAccount
      *
      * @return $this
      */
-    public function setCounterAccountNumber($counterAccountNumber);
+    public function setCounterBankAccount(BankAccount $counterBankAccount);
 
     /**
      * @return int

--- a/Tests/Statement/StatementTest.php
+++ b/Tests/Statement/StatementTest.php
@@ -2,6 +2,7 @@
 
 namespace JakubZapletal\Component\BankStatement\Tests\Statement;
 
+use JakubZapletal\Component\BankStatement\Statement\BankAccount;
 use JakubZapletal\Component\BankStatement\Statement\Statement;
 
 class StatementTest extends \PHPUnit_Framework_TestCase
@@ -67,36 +68,45 @@ class StatementTest extends \PHPUnit_Framework_TestCase
     public function testAccountNumber()
     {
         $accountNumber = '123456789';
-
-        $this->statement->setAccountNumber($accountNumber);
+        $bankAccount = new BankAccount();
+        $bankAccount->setFormatted($accountNumber);
+        $this->statement->setBankAccount($bankAccount);
         $this->assertEquals($accountNumber, $this->statement->getAccountNumber());
     }
 
     public function testParsedAccountNumber()
     {
         $accountNumber = '1231234567890/0100';
-        $this->statement->setAccountNumber($accountNumber);
+        $bankAccount = new BankAccount();
+        $bankAccount->setFormatted($accountNumber);
+        $this->statement->setBankAccount($bankAccount);
         $parsedAccountNumber = $this->statement->getParsedAccountNumber();
         $this->assertEquals('123', $parsedAccountNumber['prefix']);
         $this->assertEquals('1234567890', $parsedAccountNumber['number']);
         $this->assertEquals('0100', $parsedAccountNumber['bankCode']);
 
         $accountNumber = '123-1234567890/0100';
-        $this->statement->setAccountNumber($accountNumber);
+        $bankAccount = new BankAccount();
+        $bankAccount->setFormatted($accountNumber);
+        $this->statement->setBankAccount($bankAccount);
         $parsedAccountNumber = $this->statement->getParsedAccountNumber();
         $this->assertEquals('123', $parsedAccountNumber['prefix']);
         $this->assertEquals('1234567890', $parsedAccountNumber['number']);
         $this->assertEquals('0100', $parsedAccountNumber['bankCode']);
 
         $accountNumber = '123456789/0100';
-        $this->statement->setAccountNumber($accountNumber);
+        $bankAccount = new BankAccount();
+        $bankAccount->setFormatted($accountNumber);
+        $this->statement->setBankAccount($bankAccount);
         $parsedAccountNumber = $this->statement->getParsedAccountNumber();
         $this->assertNull($parsedAccountNumber['prefix']);
         $this->assertEquals('123456789', $parsedAccountNumber['number']);
         $this->assertEquals('0100', $parsedAccountNumber['bankCode']);
 
         $accountNumber = '1231234567890';
-        $this->statement->setAccountNumber($accountNumber);
+        $bankAccount = new BankAccount();
+        $bankAccount->setFormatted($accountNumber);
+        $this->statement->setBankAccount($bankAccount);
         $parsedAccountNumber = $this->statement->getParsedAccountNumber();
         $this->assertEquals('123', $parsedAccountNumber['prefix']);
         $this->assertEquals('1234567890', $parsedAccountNumber['number']);
@@ -109,21 +119,18 @@ class StatementTest extends \PHPUnit_Framework_TestCase
         $transactionMock_1
             ->expects($this->any())
             ->method('getReceiptId')
-            ->will($this->returnValue(11))
-        ;
+            ->will($this->returnValue(11));
 
         $transactionMock_2 = $this->getMock('JakubZapletal\Component\BankStatement\Statement\Transaction\Transaction');
         $transactionMock_2
             ->expects($this->any())
             ->method('getReceiptId')
-            ->will($this->returnValue(22))
-        ;
+            ->will($this->returnValue(22));
 
         $this->statement
             ->addTransaction($transactionMock_1)
             ->addTransaction($transactionMock_2)
-            ->addTransaction($transactionMock_2)
-        ;
+            ->addTransaction($transactionMock_2);
 
         $this->assertCount(2, $this->statement->getTransactions());
 

--- a/Tests/Statement/Transaction/TransactionTest.php
+++ b/Tests/Statement/Transaction/TransactionTest.php
@@ -2,6 +2,7 @@
 
 namespace JakubZapletal\Component\BankStatement\Tests\Statement\Transaction;
 
+use JakubZapletal\Component\BankStatement\Statement\BankAccount;
 use JakubZapletal\Component\BankStatement\Statement\Transaction\Transaction;
 
 class TransactionTest extends \PHPUnit_Framework_TestCase
@@ -19,8 +20,9 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
     public function testCounterAccountNumber()
     {
         $counterAccountNumber = '123456/7890';
-
-        $this->transaction->setCounterAccountNumber($counterAccountNumber);
+        $bankAccount = new BankAccount();
+        $bankAccount->setFormatted($counterAccountNumber);
+        $this->transaction->setCounterBankAccount($bankAccount);
         $this->assertEquals($counterAccountNumber, $this->transaction->getCounterAccountNumber());
     }
 


### PR DESCRIPTION
Added support for:
- TatraBanka (SK)
- UniCredit Bank (SK)

All operations regarding account number (setters, getters, parsers) rewritten to use unified BankAccount class.